### PR TITLE
Add book notes 2023–2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 /book-notes-2020/
 /book-notes-2021/
 /book-notes-2022/
+/book-notes-2023/
+/book-notes-2024/
+/book-notes-2025/
 /approximate-expectations-of-nonlinear-multivariate-functions/
 /automate-scientific-plots-with-python-make/
 /benchmark-string-construction-in-cpp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Setup
+
+1. Install [Quarto CLI](https://quarto.org/docs/get-started/).
+2. Install [uv](https://docs.astral.sh/uv/) and sync Python dependencies:
+   ```bash
+   uv sync
+   ```
+
 ## Commands
 
 ```bash
@@ -32,6 +42,24 @@ Shadow dirs persist after render so `quarto preview`'s file-hash tracking (`Serv
 | personal | `_posts/personal/` |
 
 `index.qmd` uses four Quarto listings with `contents: "*/index.qmd"` and `include: categories:` filters to separate sections.
+
+## Creating posts
+
+Each post is a directory under `_posts/category/slug/` containing at minimum an `index.qmd`. Minimal frontmatter:
+
+```yaml
+---
+title: "Post Title"
+date: "YYYY-MM-DD"
+categories: [research]   # one of: research, reading, travel, personal
+---
+```
+
+An optional `assets/` subdirectory holds images and data files. After adding a post, run `quarto preview` or `quarto render` — the pre-render script will create the shadow dir and wire it into the listings automatically.
+
+## Styling
+
+`tpogden.scss` defines the custom theme; `_brand.yml` sets brand colours. Both light and dark modes use the same `tpogden.scss` theme (set in `_quarto.yml`). Math renders via KaTeX.
 
 ## Python
 

--- a/_posts/reading/book-notes-2011/index.qmd
+++ b/_posts/reading/book-notes-2011/index.qmd
@@ -11,11 +11,11 @@ categories: [reading]
 
 3. _The Clockwork Universe_ by Edward Dolnick
 
-4. _Logicomix_ by Apostolos Doxiadis and Christos Papadimitriou ★
+4. _Logicomix_ by Apostolos Doxiadis and Christos Papadimitriou [★]{.star}
 
 5. _Getting Things Done_ by David Allen ↻
 
-6. _Middlesex_ by Jeffrey Eugenides ★
+6. _Middlesex_ by Jeffrey Eugenides [★]{.star}
 
 7. _Stamboul Train_ by Graham Greene 
 

--- a/_posts/reading/book-notes-2012/index.qmd
+++ b/_posts/reading/book-notes-2012/index.qmd
@@ -16,7 +16,7 @@ categories: [reading]
 
 6. _How to Write a Sentence_ by Stanley Fish
 
-7. _Into The Silence_ by Wade Davies ★
+7. _Into The Silence_ by Wade Davies [★]{.star}
 
 8. _Life on Air_ by David Attenborough
 

--- a/_posts/reading/book-notes-2013/index.qmd
+++ b/_posts/reading/book-notes-2013/index.qmd
@@ -8,7 +8,7 @@ categories: [reading]
 
 2. _Green Hills of Africa_ by Ernest Hemingway
 
-3. _Adapt_ by Tim Harford ★
+3. _Adapt_ by Tim Harford [★]{.star}
 
 4. _Them_ by Jon Ronson
 
@@ -22,13 +22,13 @@ categories: [reading]
 
 9. _Steve Jobs_ by Walter Isaacson
 
-10. _Blood Meridian_ by Cormac McCarthy ★
+10. _Blood Meridian_ by Cormac McCarthy [★]{.star}
 
-11. _Slaughterhouse-Five_ by Kurt Vonnegut ★
+11. _Slaughterhouse-Five_ by Kurt Vonnegut [★]{.star}
 
 12. _NW_ by Zadie Smith
 
-13. _The Old Man and the Sea_ by Ernest Hemingway ★
+13. _The Old Man and the Sea_ by Ernest Hemingway [★]{.star}
 
 14. _Huckleberry Finn_ by Mark Twain
 

--- a/_posts/reading/book-notes-2014/index.qmd
+++ b/_posts/reading/book-notes-2014/index.qmd
@@ -4,7 +4,7 @@ date: "2014-12-31"
 categories: [reading]
 ---
 
-1. _Old School_ by Tobias Wolff ★ --- In [an interview][pr] soon after finishing _Old School_, Wolff suggests
+1. _Old School_ by Tobias Wolff [★]{.star} --- In [an interview][pr] soon after finishing _Old School_, Wolff suggests
    Robert Frost — who appears in the novel — 'didn’t fully understand his own
    poem', or pretended not to. The theme of a writer's intention comes up both
    in Frost's reading of George's story as a dig at him and Susan's reading of
@@ -31,9 +31,9 @@ categories: [reading]
 
 8. _Adventures of Hergé_ by Jose-Louis Bocquet et al.
 
-9. _Sustainable Energy Without the Hot Air_ by David J. C. MacKay ★
+9. _Sustainable Energy Without the Hot Air_ by David J. C. MacKay [★]{.star}
 
-10. _Breakfast of Champions_ by Kurt Vonnegut ★
+10. _Breakfast of Champions_ by Kurt Vonnegut [★]{.star}
 
 11. _The Sun Also Rises_ by Ernest Hemingway
 

--- a/_posts/reading/book-notes-2015/index.qmd
+++ b/_posts/reading/book-notes-2015/index.qmd
@@ -14,7 +14,7 @@ categories: [reading]
 
 1. _Body of Work_ by Pamela Slim
 
-1. _Behind the Beautiful Forevers_ by Katherine Boo ★
+1. _Behind the Beautiful Forevers_ by Katherine Boo [★]{.star}
 
 1. _1Q84, Book II_ by Haruki Murakami
 
@@ -34,7 +34,7 @@ categories: [reading]
 
 1. _South of the Border, West of the Sun_ by Haruki Murakami
 
-1. _To Kill a Mockingbird_ by Harper Lee ★
+1. _To Kill a Mockingbird_ by Harper Lee [★]{.star}
 
 1. _New York City: A Short History_ by George J. Lankevich
 

--- a/_posts/reading/book-notes-2016/index.qmd
+++ b/_posts/reading/book-notes-2016/index.qmd
@@ -54,7 +54,7 @@ categories: [reading]
    union-controlled labour market policy did not protect jobs but assisted
    workers to become mobile and retrain.
 
-1. _The Crossing_ by Cormac McCarthy ★ --- The second book in the Border Trilogy is a story of three
+1. _The Crossing_ by Cormac McCarthy [★]{.star} --- The second book in the Border Trilogy is a story of three
    crossings of the Texas border by the teenaged Billy Parham. The first is a
    dreamlike journey to return a wild, pregnant wolf to its Mexican mountain
    home, the second and third follow in fate and circumstance.
@@ -68,11 +68,11 @@ categories: [reading]
    footsore dog', 'the needlethin sweepsecond hand sectoring the dial'. The best
    are often saved for his keen-eyed attention to the animals.
 
-1. _The Secret History_ by Donna Tartt ★ --- Pretty sure if I'd read this novel before 2012 I would not have
+1. _The Secret History_ by Donna Tartt [★]{.star} --- Pretty sure if I'd read this novel before 2012 I would not have
    spent the next three years living with classicists.
 
 
-1. _Prisoners of Geography_ by Tim Marshall ★ --- With our century's aircraft, internet and supranational
+1. _Prisoners of Geography_ by Tim Marshall [★]{.star} --- With our century's aircraft, internet and supranational
    institutions, we may be tempted to think we've overcome the bounds of
    physical geography in global affairs. Our history is told in ideologies and
    leaders, good or bad.
@@ -144,7 +144,7 @@ categories: [reading]
    part his account of the open road and the the characters he finds on it is
    warm.
 
-1. _My Ántonia_ by Willa Carther ★ --- A tough, romantic tale of the immigrant life of early settlers on the
+1. _My Ántonia_ by Willa Carther [★]{.star} --- A tough, romantic tale of the immigrant life of early settlers on the
    Nebraska plain in the age of the Homestead Act.
 
    > There seemed to be nothing to see; no fences, no creeks or trees, no hills

--- a/_posts/reading/book-notes-2017/index.qmd
+++ b/_posts/reading/book-notes-2017/index.qmd
@@ -28,14 +28,14 @@ redirect_from:
 1. _The Hunt for Red October_ by Tom Clancy --- I always
    picture Jack Ryan as Alec Baldwin.
 
-1. _The Lowland_ by Jhumpa Lahiri ★ --- A sweeping but intimate novel that starts in 1960s Calcutta with two
+1. _The Lowland_ by Jhumpa Lahiri [★]{.star} --- A sweeping but intimate novel that starts in 1960s Calcutta with two
    young brothers, Subhash and Udayan. Their lives fork, an impulsive Udayan
    caught up in the Naxalite movement at home and a studious Subhash setting out
    for university and a life in New England. It's about staying and leaving,
    about parenthood, loss, guilt and responsibility, through four generations of
    a family.
 
-1. _Endurance_ by Alfred Lansing ★ ↻ Lansing wrote this authoritative account of the Endurance expedition,
+1. _Endurance_ by Alfred Lansing [★]{.star} ↻ Lansing wrote this authoritative account of the Endurance expedition,
    having got hold of most of the diaries kept on the voyage and then
    interviewed the surviving crew. The mission of the great explorer to make the
    first land crossing of the Antarctic went awry when the tallship got stuck in
@@ -78,7 +78,7 @@ redirect_from:
    and the Catholic church's successful absorption of the monastic movement to
    bring it under its own control.
 
-1. _Deep Work_ by Cal Newport ★ ↻ This book felt important, and I just counted the number of passages I've
+1. _Deep Work_ by Cal Newport [★]{.star} ↻ This book felt important, and I just counted the number of passages I've
    added to my notes from it:  94, which is maybe a record. This is close enough
    to the central thesis:
 
@@ -155,7 +155,7 @@ redirect_from:
    about it in the old days—‘In Another Country,’ ‘A Way You’ll Never Be,’ and
    ‘Now I Lay Me.’
 
-1. _The Goldfinch_ by Donna Tartt ★ --- This and _The Secret History_ are two of the most enjoyable novels I can
+1. _The Goldfinch_ by Donna Tartt [★]{.star} --- This and _The Secret History_ are two of the most enjoyable novels I can
    remember reading in a long time. Recommended by everyone, and now by me.
 
    > Caring too much for objects can destroy you. Only–if you care for a thing
@@ -256,7 +256,7 @@ redirect_from:
    direction, like Zimmermann with his [Telegram][tele] and most significantly
    Genghis Khan.
 
-3. _The Vital Question_ by Nick Lane ★ --- Lane takes us through a radical, wide-ranging new theory on the
+3. _The Vital Question_ by Nick Lane [★]{.star} --- Lane takes us through a radical, wide-ranging new theory on the
    origins of life and then complex life. The theory puts energy right at the
    centre of the problem with the sort of derivation from first principles you
    get in physics. So I enjoyed that.
@@ -309,7 +309,7 @@ redirect_from:
    years, and where this could take us.
 
 
-6. _Killers of the Flower Moon_ by David Grann ★ --- This is a shocking, tragic crime history from 1920s
+6. _Killers of the Flower Moon_ by David Grann [★]{.star} --- This is a shocking, tragic crime history from 1920s
    Oklahoma. The sisters in a family of the Osage tribe of Native Americans,
    rich from oil strikes on the rocky land they'd been shoved onto, started
    dying off. The surviving family have to pay for the new federal Bureau of

--- a/_posts/reading/book-notes-2018/index.qmd
+++ b/_posts/reading/book-notes-2018/index.qmd
@@ -29,14 +29,14 @@ redirect_from:
 1. _The Hunt for Red October_ by Tom Clancy --- I always
    picture Jack Ryan as Alec Baldwin.
 
-1. _The Lowland_ by Jhumpa Lahiri ★ --- A sweeping but intimate novel that starts in 
+1. _The Lowland_ by Jhumpa Lahiri [★]{.star} --- A sweeping but intimate novel that starts in 
    1960s Calcutta with two young brothers, Subhash and Udayan. Their lives fork, an 
    impulsive Udayan caught up in the Naxalite movement at home and a studious Subhash 
    setting out for university and a life in New England. It's about staying and leaving,
    about parenthood, loss, guilt and responsibility, through four generations of
    a family.
 
-1. _Endurance_ by Alfred Lansing ★ --- Lansing wrote this authoritative account of the Endurance expedition,
+1. _Endurance_ by Alfred Lansing [★]{.star} --- Lansing wrote this authoritative account of the Endurance expedition,
    having got hold of most of the diaries kept on the voyage and then
    interviewed the surviving crew. The mission of the great explorer to make the
    first land crossing of the Antarctic went awry when the tallship got stuck in
@@ -79,7 +79,7 @@ redirect_from:
    and the Catholic church's successful absorption of the monastic movement to
    bring it under its own control.
 
-1. _Deep Work_ by Cal Newport ★ --- This book felt important, and I just counted the 
+1. _Deep Work_ by Cal Newport [★]{.star} --- This book felt important, and I just counted the 
    number of passages I've
    added to my notes from it:  94, which is maybe a record. This is close enough
    to the central thesis:
@@ -157,7 +157,7 @@ redirect_from:
    about it in the old days—‘In Another Country,’ ‘A Way You’ll Never Be,’ and
    ‘Now I Lay Me.’
 
-1. _The Goldfinch_ by Donna Tartt ★  --- This and _The Secret History_ are two of the 
+1. _The Goldfinch_ by Donna Tartt [★]{.star}  --- This and _The Secret History_ are two of the 
    most enjoyable novels I can remember reading in a long time. Recommended by everyone, 
    and now by me.
 
@@ -260,7 +260,7 @@ redirect_from:
    direction, like Zimmermann with his [Telegram][tele] and most significantly
    Genghis Khan.
 
-3. _The Vital Question_ by Nick Lane ★ --- Lane takes us through a radical, wide-ranging new theory on the
+3. _The Vital Question_ by Nick Lane [★]{.star} --- Lane takes us through a radical, wide-ranging new theory on the
    origins of life and then complex life. The theory puts energy right at the
    centre of the problem with the sort of derivation from first principles you
    get in physics. So I enjoyed that.
@@ -313,7 +313,7 @@ redirect_from:
    years, and where this could take us.
 
 
-6. _Killers of the Flower Moon_ by David Grann ★ --- This is a shocking, tragic crime 
+6. _Killers of the Flower Moon_ by David Grann [★]{.star} --- This is a shocking, tragic crime 
    history from 1920s Oklahoma. The sisters in a family of the Osage tribe of Native 
    Americans, rich from oil strikes on the rocky land they'd been shoved onto, started
    dying off. The surviving family have to pay for the new federal Bureau of

--- a/_posts/reading/book-notes-2019/index.qmd
+++ b/_posts/reading/book-notes-2019/index.qmd
@@ -41,7 +41,7 @@ categories: [reading]
    about orbital mechanics. The third part, the real sci-fi bit, took a while
    for me to see the point of.
  
-6. _Janesville_ by Amy Goldstein ★ --- The modern history of one industrial city in Wisconsin. Janesville was
+6. _Janesville_ by Amy Goldstein [★]{.star} --- The modern history of one industrial city in Wisconsin. Janesville was
     the home of the Parker pen company and had the oldest General Motors factory
     in the US until it closed in 2008. The book follows a few of the residents
     affected by the plant closure over the following five years. These
@@ -106,7 +106,7 @@ categories: [reading]
     this one. Something between a spy novel and a mystery set in Bonn in the
     60s.
 
-12. _So Good They Can't Ignore You_ by Cal Newport ★ --- 'Follow your passion' is terrible advice.
+12. _So Good They Can't Ignore You_ by Cal Newport [★]{.star} --- 'Follow your passion' is terrible advice.
 
 13. _Empire_ by Stephen Howe --- Howe splits empires into
     those on land and those of sea. Land empires being those that grew by
@@ -233,7 +233,7 @@ categories: [reading]
     rebuttal to [the title essay][pg-hp], see that other programmer, painter and
     solid writer [Maciej Cegłowski][dabblers]. 
     
-24. _Triumph of the City_ by Edward L. Glaeser ★ --- I've lived most of my adult life 
+24. _Triumph of the City_ by Edward L. Glaeser [★]{.star} --- I've lived most of my adult life 
     in the centre of
     cities, not by accident. Harvard urban economist Edward Glaeser here makes
     the case for urban life. First, on the agglomeration effects that have made
@@ -330,7 +330,7 @@ categories: [reading]
     [Seychelles][flag-sey], [Brazil][flag-br], [Vietnam][flag-v]. And
     [Nepal][flag-n] because yeah, enough rectangles.
 
-28. _Madness Visible_ by Janine di Giovanni ★ --- I made trips to Slovenia and Croatia 
+28. _Madness Visible_ by Janine di Giovanni [★]{.star} --- I made trips to Slovenia and Croatia 
     this year, both beautiful, modern EU states. I picked this up in a bookshop in 
     Dubrovnik: Di Giovanni's memoir of the Balkan Wars, which she covered on the ground 
     for _The Times_. It's a harrowing firsthand account of the devestating reality of 

--- a/_posts/reading/book-notes-2020/index.qmd
+++ b/_posts/reading/book-notes-2020/index.qmd
@@ -4,7 +4,7 @@ date: "2020-12-31"
 categories: [reading]
 ---
 
-1. [_The Big Sleep_][bs-big-sleep] by Raymond Chandler ★ --- The first Philip
+1. [_The Big Sleep_][bs-big-sleep] by Raymond Chandler [★]{.star} --- The first Philip
    Marlowe book. I have to write 'hardboiled' here.
   
 2. [_I, Robot_][bs-i-robot] by Peter Crouch --- Bought for the title.
@@ -48,7 +48,7 @@ categories: [reading]
    France. Barr sources declassified archives to tell the inglorious colonialist
    history through the decades that followed.
 
-10. [_The Idea of the Brain_][bs-brain] by Matthew Cobb ★
+10. [_The Idea of the Brain_][bs-brain] by Matthew Cobb [★]{.star}
     --- An enlightening history of our understanding of probably the most
     complex and inscrutible object we know of. The book combines a chronicle of
     ideas since Aristotle and a tour of the current state of neuroscience.
@@ -88,7 +88,7 @@ categories: [reading]
     > living in a slum, for some reason owning a whole street of them merely got
     > you invited to the very best social occasions.
 
-12. [_The Warmth of Other Suns_][bs-warmth] by Isabel Wilkerson ★ --- A narrative history of the Great Migration of African
+12. [_The Warmth of Other Suns_][bs-warmth] by Isabel Wilkerson [★]{.star} --- A narrative history of the Great Migration of African
     Americans from the Southern US to Northern and West Coast cities in the
     twentieth century, pushed by Jim Crow oppression and terror in the South and
     pulled by demand for factory labour in the North.
@@ -162,7 +162,7 @@ categories: [reading]
     United States can be thought of as a third era of segregation after slavery
     and Jim Crow laws.
 
-18. [_The Sum of the People_][bs-sum] by Andrew Whitby ★
+18. [_The Sum of the People_][bs-sum] by Andrew Whitby [★]{.star}
     --- Counting people might sound like an uncontroversial and mundane
     statistical[^stats] task, but this history of the census since the idea's
     origins in ancient China is absorbing. The Exodus of the Israelites in the
@@ -201,7 +201,7 @@ categories: [reading]
     > thinks of themselves as one of Them. We're always one of Us. It's Them
     > that do the bad things.
 
-20. [_The Left Hand of Darkness_][bs-left-hand] by Ursula K. Le Guin ★ --- I enjoyed this a lot once I'd gotten into the
+20. [_The Left Hand of Darkness_][bs-left-hand] by Ursula K. Le Guin [★]{.star} --- I enjoyed this a lot once I'd gotten into the
     world-building terminology, especially the final trek across the ice sheet
     back to Karhide.
 
@@ -211,7 +211,7 @@ categories: [reading]
     United States in terms of a caste system.
 
 22. [_Hateship, Friendship, Courtship, Loveship, Marriage_][bs-hateship] by
-    Alice Munro ★ --- I love how Munro will settle you
+    Alice Munro [★]{.star} --- I love how Munro will settle you
     into this familiar place, probably in rural Canada, probably with some
     midlife characters, then unsettle you in just a few pages.
 
@@ -237,7 +237,7 @@ categories: [reading]
     process leading to the Navy SEAL kill-or-capture operation for Osama bin
     Laden. I look forward to the next volume.
 
-28. [_The Moth and the Mountain_][bs-moth] by Ed Caesar ★
+28. [_The Moth and the Mountain_][bs-moth] by Ed Caesar [★]{.star}
     --- An adventure. After the early attempts to conquer Everest by George
     Mallory[^silence] and others, in 1934 Bradfordian WWI veteran Maurice Wilson
     made an eccentric solo attempt to stand first on Earth's highest point by

--- a/_posts/reading/book-notes-2021/index.qmd
+++ b/_posts/reading/book-notes-2021/index.qmd
@@ -83,7 +83,7 @@ categories: [reading]
     and the boys are pushed to the edge of society (and town) but still have a
     plan to make something happen.
 
-18. [_The Best We Could Do_][bs-bwcd] by Thi Bui ★ ---
+18. [_The Best We Could Do_][bs-bwcd] by Thi Bui [★]{.star} ---
     This graphic memoir starts at the end with Bui's new motherhood and
     navigates from there her relationships with her own parents and siblings,
     telling their story of life in South Vietnam, colonialism and war, dangerous
@@ -107,7 +107,7 @@ categories: [reading]
     mass pirated MP3s and before the rise of Spotify and the vinyl revival so
     there's a negative outlook written in.
 
-22. [_The Story of China_][bs-china] by Michael Wood ★ ---
+22. [_The Story of China_][bs-china] by Michael Wood [★]{.star} ---
     The innovation in the Song dynasty up to the 1200s, compared with Europe at
     the time, is unparalleled. Public opinion in Britain was largely against the
     Opium wars.
@@ -127,7 +127,7 @@ categories: [reading]
     approval from village to village, hopefully from from the right warlord. He
     might have had a better go at a pandemic anyway.
 
-26. [_The Man from the Future_][bs-future] by Ananyo Bhattacharya ★ --- The [Manchester Baby][baby][^mbaby] is generally recognised
+26. [_The Man from the Future_][bs-future] by Ananyo Bhattacharya [★]{.star} --- The [Manchester Baby][baby][^mbaby] is generally recognised
     as the first electronic stored program computer but Bhattacharya makes the
     case that Klára von Neumann's earlier program for the ENIAC could be
     considered stored. It strikes me how much of my own career so far has been

--- a/_posts/reading/book-notes-2023/index.qmd
+++ b/_posts/reading/book-notes-2023/index.qmd
@@ -1,0 +1,29 @@
+---
+title: "Book Notes, 2023"
+date: "2023-12-31"
+categories: [reading]
+---
+
+1. _Uneasy Peace_ by Patrick Sharkey
+
+2. _A Passage North_ by Anuk Arudpragasam
+
+3. _Apollo_ by Matt Fitch, Chris Baker and Mike Collins
+
+4. _The Passenger_ by Cormac McCarthy
+
+5. _The Shadow Puppet_ by Georges Simenon
+
+6. _The Saint-Fiacre Affair_ by Georges Simenon
+
+7. _Batman: The Dark Knight Returns_ by Frank Miller
+
+8. _Mayflies_ by Andrew O'Hagan
+
+9. _The Light Fantastic_ by Terry Pratchett
+
+10. _Chip War_ by Chris Miller
+
+11. _And Away..._ by Bob Mortimer
+
+12. _Walking on Air_ by Geoff Nicholson

--- a/_posts/reading/book-notes-2024/index.qmd
+++ b/_posts/reading/book-notes-2024/index.qmd
@@ -1,0 +1,41 @@
+---
+title: "Book Notes, 2024"
+date: "2024-12-31"
+categories: [reading]
+---
+
+1. _Flowers for Algernon_ by Daniel Keyes
+
+2. _How to Hide an Empire_ by Daniel Immerwahr [★]{.star}
+
+3. _Infinite Powers_ by Steven Strogatz
+
+4. _Carmageddon_ by Daniel Knowles
+
+5. _Chasing Shadows_ by Miles Johnson
+
+6. _Working_ by Robert Caro
+
+7. _The Fraud_ by Zadie Smith
+
+8. _Typhoon_ by Mike Sutton
+
+9. _Riverman_ by Ben McGrath
+
+10. _Lost Rainforests of Britain_ by Guy Shrubsole [★]{.star}
+
+11. _Say Nothing_ by Patrick Radden Keefe [★]{.star}
+
+12. _Feral_ by George Monbiot
+
+13. _This Isn't Happening_ by Steven Hyden
+
+14. _Wilding_ by Isabella Tree
+
+15. _A History of the World in 47 Borders_ by Jonn Elledge
+
+16. _Tomorrow, and Tomorrow, and Tomorrow_ by Gabrielle Zevin [★]{.star}
+
+17. _Equal Rites_ by Terry Pratchett
+
+18. _Polostan_ by Neal Stephenson

--- a/_posts/reading/book-notes-2025/index.qmd
+++ b/_posts/reading/book-notes-2025/index.qmd
@@ -1,0 +1,43 @@
+---
+title: "Book Notes, 2025"
+date: "2025-12-31"
+categories: [reading]
+---
+
+1. _The Secret Hours_ by Mick Herron
+
+2. _London Rules (Slough House #5)_ by Mick Herron
+
+3. _The Drop (Slough House #5.5)_ by Mick Herron
+
+4. _This Naked Mind_ by Annie Grace
+
+5. _Joe Country (Slough House #6)_ by Mick Herron
+
+6. _The Catch (Slough House #6.3)_ by Mick Herron
+
+7. _Abundance_ by Ezra Klein and Derek Thompson
+
+8. _Blood, Sweat, and Pixels_ by Jason Schreier
+
+9. _Slough House (Slough House #7)_ by Mick Herron
+
+10. _Faceless Killers_ by Henning Mankell
+
+11. _The Dogs of Riga_ by Henning Mankell
+
+12. _The Infernal Machine_ by Steven Johnson [★]{.star}
+
+13. _Bad Actors (Slough House #8)_ by Mick Herron
+
+14. _The White Lioness_ by Henning Mankell
+
+15. _Orbital_ by Samantha Harvey
+
+16. _Mort_ by Terry Pratchett
+
+17. _Clown Town (Slough House #9)_ by Mick Herron
+
+18. _Nuking Alaska_ by Peter Dunlap-Shohl
+
+19. _Things Become Other Things_ by Craig Mod [★]{.star}

--- a/scripts/pre-render.sh
+++ b/scripts/pre-render.sh
@@ -4,7 +4,7 @@
 # Shadow dirs persist after rendering so quarto preview can hash source files.
 
 # Keep .gitignore in sync with current post slugs
-sed -i '/^# post shadow dirs$/,/^# end post shadow dirs$/d' .gitignore
+sed -i '' '/^# post shadow dirs$/,/^# end post shadow dirs$/d' .gitignore
 {
     echo "# post shadow dirs"
     for post_dir in _posts/*/*/; do

--- a/tpogden.scss
+++ b/tpogden.scss
@@ -211,3 +211,6 @@ div.quarto-post {
     color: $grey-mid;
     font-size: 0.875em;
 }
+
+// Starred books
+.star { color: $main; }


### PR DESCRIPTION
## Summary

- Add book notes posts for 2023, 2024, and 2025 (outline format, starred highlights in tangerine)
- Wrap all ★ in `[★]{.star}` spans across all existing years; add `.star { color: $main }` to `tpogden.scss` so stars render in the primary tangerine colour site-wide
- Fix `sed -i ''` in `pre-render.sh` (missing empty-string arg broke macOS sed, causing duplicate `.gitignore` blocks)
- Expand `CLAUDE.md` with setup instructions, post creation guide, and styling notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)